### PR TITLE
Implement using deasync

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A synchronous wrapper for glslify, providing a consistent interface between both Node.js and browserify",
   "main": "index.js",
   "files": [
-    "index.js", "transform.js"
+    "index.js",
+    "transform.js"
   ],
   "license": "MIT",
   "author": {
@@ -17,8 +18,10 @@
   ],
   "dependencies": {
     "callsite": "^1.0.0",
+    "deasync": "^0.1.4",
     "glslify": "^5.0.2",
-    "module-bin": "0.0.1"
+    "glslify-bundle": "^5.0.0",
+    "glslify-deps": "^1.2.5"
   },
   "devDependencies": {
     "cln": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
   ],
   "dependencies": {
     "callsite": "^1.0.0",
-    "deasync": "^0.1.4",
     "glslify": "^5.0.2",
     "glslify-bundle": "^5.0.0",
-    "glslify-deps": "^1.2.5"
+    "glslify-deps": "^1.2.5",
+    "module-bin": "0.0.1"
+  },
+  "optionalDependencies": {
+    "deasync": "^0.1.4"
   },
   "devDependencies": {
     "cln": "^1.0.0"


### PR DESCRIPTION
Hi @vorg!

This is version implemented via [deasync](https://npmjs.org/package/deasync). It works perfectly and times faster, but it takes _node-gyp_ to compile, though.
Technically I could try fallback to module-bin if installing of deasync fails.
