### PR TITLE
Add failing async test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,10 @@ var clean = require('cln');
 var fixture = fs.readFileSync(path.resolve(__dirname, './shader.glsl'), 'utf-8');
 
 
-var result = glslify('./shader.glsl');
-result = result.replace(/#[^\n]*/, '');
+setTimeout(function () {
+	var result = glslify('./shader.glsl');
 
-assert.equal(clean(result), clean(fixture));
+	result = result.replace(/#[^\n]*/, '');
+
+	assert.equal(clean(result), clean(fixture));
+});


### PR DESCRIPTION
Deasync fails on async context. It requires fixing.
Related with https://github.com/abbr/deasync/issues/21
The issue https://github.com/vorg/glslify-sync/issues/6
